### PR TITLE
Automatically deploy example app to Heroku

### DIFF
--- a/.github/workflows/deploy-example-app.yml
+++ b/.github/workflows/deploy-example-app.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: akhileshns/heroku-deploy@v3.8.8
         with:
           heroku_api_key: £{{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: "ably-mapbox-demo"
+          heroku_app_name: "ably-asset-tracking-demo"
           heroku_email: heroku@ably.io
           procfile: "web: cd examples/subscribing-example-app && npm ci && npm start"


### PR DESCRIPTION
If merged, this PR will add a GitHub workflow to automatically deploy the subscriber example app to Heroku on pushes to the `main` branch.