### PR TITLE
Use force push to Heroku app

### DIFF
--- a/.github/workflows/deploy-example-app.yml
+++ b/.github/workflows/deploy-example-app.yml
@@ -13,4 +13,5 @@ jobs:
           heroku_api_key: £{{ secrets.HEROKU_API_KEY }}
           heroku_app_name: "ably-asset-tracking-demo"
           heroku_email: heroku@ably.io
+          dontuseforce: false
           procfile: "web: cd examples/subscribing-example-app && npm ci && npm start"


### PR DESCRIPTION
The `heroku-deploy` action fails because we are trying to overwrite the existing git repository on the heroku remote. This PR should make the action use force push so that this won't block the deployment.