### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy-example-app.yml
+++ b/.github/workflows/deploy-example-app.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: git remote add heroku https://git.heroku.com/vast-hollows-59409.git
       - uses: akhileshns/heroku-deploy@v3.8.8
         with:
           heroku_api_key: £{{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
Adds the git remote before running the 'deploy' action. Hopefully this should allow the deploy action to run without error and deploy the app to the heroku remote.