### PR TITLE
Add resolution and location update interval listeners to the Subscriber SDK

### DIFF
--- a/src/lib/Subscriber.ts
+++ b/src/lib/Subscriber.ts
@@ -1,5 +1,12 @@
 import { Types as AblyTypes } from 'ably';
-import { LocationListener, Resolution, StatusListener, SubscriberOptions } from '../types';
+import {
+  LocationListener,
+  LocationUpdateIntervalListener,
+  Resolution,
+  ResolutionListener,
+  StatusListener,
+  SubscriberOptions,
+} from '../types';
 import AssetConnection from './AssetConnection';
 import Logger from './utils/Logger';
 
@@ -8,6 +15,8 @@ class Subscriber {
   onStatusUpdate?: StatusListener;
   onLocationUpdate?: LocationListener;
   onRawLocationUpdate?: LocationListener;
+  onResolutionUpdate?: ResolutionListener;
+  onLocationUpdateIntervalUpdate?: LocationUpdateIntervalListener;
   logger: Logger;
   assetConnection?: AssetConnection;
   resolution?: Resolution;
@@ -18,6 +27,8 @@ class Subscriber {
     this.onStatusUpdate = options.onStatusUpdate;
     this.onLocationUpdate = options.onLocationUpdate;
     this.onRawLocationUpdate = options.onRawLocationUpdate;
+    this.onResolutionUpdate = options.onResolutionUpdate;
+    this.onLocationUpdateIntervalUpdate = options.onLocationUpdateIntervalUpdate;
     this.resolution = options.resolution;
   }
 
@@ -29,6 +40,8 @@ class Subscriber {
       this.onLocationUpdate,
       this.onRawLocationUpdate,
       this.onStatusUpdate,
+      this.onResolutionUpdate,
+      this.onLocationUpdateIntervalUpdate,
       this.resolution
     );
     await this.assetConnection.joinChannelPresence();

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -33,6 +33,16 @@ export type SubscriberOptions = {
    * The desired resolution of updates, to be requested from the remote publisher.
    */
   resolution?: Resolution;
+
+  /**
+   * A callback to be notified when the publisher's calculated resolution of the asset changes.
+   */
+  onResolutionUpdate?: ResolutionListener;
+
+  /**
+   * A callback to be notified when the interval between location updates of the asset changes.
+   */
+  onLocationUpdateIntervalUpdate?: LocationUpdateIntervalListener;
 };
 
 type GeoJsonProperties = {
@@ -55,6 +65,10 @@ export type LocationUpdate = {
 export type LocationListener = (locationUpdate: LocationUpdate) => unknown;
 
 export type StatusListener = (isOnline: boolean) => unknown;
+
+export type ResolutionListener = (resolution: Resolution) => unknown;
+
+export type LocationUpdateIntervalListener = (locationUpdateInterval: number) => unknown;
 
 /**
  * Governs how often to sample locations, at what level of positional accuracy, and how often to send them to

--- a/test/unit/AssetConnection.test.ts
+++ b/test/unit/AssetConnection.test.ts
@@ -93,6 +93,8 @@ describe('AssetConnection', () => {
       undefined,
       undefined,
       undefined,
+      undefined,
+      undefined,
       resolution
     ).joinChannelPresence();
 
@@ -200,6 +202,116 @@ describe('AssetConnection', () => {
 
     expect(onStatusUpdate).toHaveBeenCalledTimes(1);
     expect(onStatusUpdate).toHaveBeenCalledWith(false);
+  });
+
+  it('should call publisher resolution listeners when publisher enters channel presence and has a resolution', () => {
+    const onResolutionUpdate = jest.fn();
+    const onLocationUpdateIntervalUpdate = jest.fn();
+    const publisherResolution = { accuracy: 'BALANCED', desiredInterval: 1, minimumDisplacement: 1.0 };
+    const presenceMessage = {
+      data: {
+        type: ClientTypes.Publisher,
+        resolution: publisherResolution,
+      },
+      action: 'enter',
+    };
+    mockPresenceSubscribe.mockImplementation((fn) => fn(presenceMessage));
+    new AssetConnection(
+      new Logger(),
+      trackingId,
+      ablyOptions,
+      undefined,
+      undefined,
+      undefined,
+      onResolutionUpdate,
+      onLocationUpdateIntervalUpdate
+    ).joinChannelPresence();
+
+    expect(onResolutionUpdate).toHaveBeenCalledTimes(1);
+    expect(onResolutionUpdate).toHaveBeenCalledWith(publisherResolution);
+    expect(onLocationUpdateIntervalUpdate).toHaveBeenCalledTimes(1);
+    expect(onLocationUpdateIntervalUpdate).toHaveBeenCalledWith(publisherResolution.desiredInterval);
+  });
+
+  it('should not call publisher resolution listeners when publisher enters channel presence and does not have a resolution', () => {
+    const onResolutionUpdate = jest.fn();
+    const onLocationUpdateIntervalUpdate = jest.fn();
+    const presenceMessage = {
+      data: {
+        type: ClientTypes.Publisher,
+        resolution: null,
+      },
+      action: 'enter',
+    };
+    mockPresenceSubscribe.mockImplementation((fn) => fn(presenceMessage));
+    new AssetConnection(
+      new Logger(),
+      trackingId,
+      ablyOptions,
+      undefined,
+      undefined,
+      undefined,
+      onResolutionUpdate,
+      onLocationUpdateIntervalUpdate
+    ).joinChannelPresence();
+
+    expect(onResolutionUpdate).toHaveBeenCalledTimes(0);
+    expect(onLocationUpdateIntervalUpdate).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call publisher resolution listeners when publisher updates channel presence and has a resolution', () => {
+    const onResolutionUpdate = jest.fn();
+    const onLocationUpdateIntervalUpdate = jest.fn();
+    const publisherResolution = { accuracy: 'BALANCED', desiredInterval: 1, minimumDisplacement: 1.0 };
+    const presenceMessage = {
+      data: {
+        type: ClientTypes.Publisher,
+        resolution: publisherResolution,
+      },
+      action: 'update',
+    };
+    mockPresenceSubscribe.mockImplementation((fn) => fn(presenceMessage));
+    new AssetConnection(
+      new Logger(),
+      trackingId,
+      ablyOptions,
+      undefined,
+      undefined,
+      undefined,
+      onResolutionUpdate,
+      onLocationUpdateIntervalUpdate
+    ).joinChannelPresence();
+
+    expect(onResolutionUpdate).toHaveBeenCalledTimes(1);
+    expect(onResolutionUpdate).toHaveBeenCalledWith(publisherResolution);
+    expect(onLocationUpdateIntervalUpdate).toHaveBeenCalledTimes(1);
+    expect(onLocationUpdateIntervalUpdate).toHaveBeenCalledWith(publisherResolution.desiredInterval);
+  });
+
+  it('should not call publisher resolution listeners when publisher updates channel presence and does not have a resolution', () => {
+    const onResolutionUpdate = jest.fn();
+    const onLocationUpdateIntervalUpdate = jest.fn();
+    const presenceMessage = {
+      data: {
+        type: ClientTypes.Publisher,
+        resolution: null,
+      },
+      action: 'update',
+    };
+    mockPresenceSubscribe.mockImplementation((fn) => fn(presenceMessage));
+    new AssetConnection(
+      new Logger(),
+      trackingId,
+      ablyOptions,
+      undefined,
+      undefined,
+      undefined,
+      onResolutionUpdate,
+      onLocationUpdateIntervalUpdate
+    ).joinChannelPresence();
+
+    expect(onResolutionUpdate).toHaveBeenCalledTimes(0);
+    expect(onLocationUpdateIntervalUpdate).toHaveBeenCalledTimes(0);
   });
 
   it('should execute enhancedLocationListener with location message when publisher publishes enhanced location message', () => {

--- a/test/unit/AssetSubscriber.test.ts
+++ b/test/unit/AssetSubscriber.test.ts
@@ -53,6 +53,8 @@ describe('Subscriber', () => {
     const onStatusUpdate = jest.fn();
     const onLocationUpdate = jest.fn();
     const onRawLocationUpdate = jest.fn();
+    const onResolutionUpdate = jest.fn();
+    const onLocationUpdateIntervalUpdate = jest.fn();
 
     const loggerOptions = {
       level: 5,
@@ -70,6 +72,8 @@ describe('Subscriber', () => {
       onRawLocationUpdate,
       loggerOptions,
       resolution,
+      onResolutionUpdate,
+      onLocationUpdateIntervalUpdate,
     });
 
     subscriber.start(trackingId);
@@ -82,6 +86,8 @@ describe('Subscriber', () => {
       onLocationUpdate,
       onRawLocationUpdate,
       onStatusUpdate,
+      onResolutionUpdate,
+      onLocationUpdateIntervalUpdate,
       resolution
     );
   });


### PR DESCRIPTION
I've added listeners for the publisher resolution and location update interval to the Subscriber SDK. This should allow us to make the map animations smoother.