### PR TITLE
CI: Remove deprecated playwright action and pin ubuntu version

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: microsoft/playwright-github-action@v1
+      - run: npx playwright install-deps
       - run: npm ci
       - run: npm run lint
       - run: npm run check-formatting


### PR DESCRIPTION
Fixes an error where CI would fail when running integration tests