### PR TITLE
ci: pin node version to 16.x

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
       - run: npx playwright install-deps
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
resolves a build error due to changes in openssl compat in node 18